### PR TITLE
Add event crawling (cu, gs, emart24)

### DIFF
--- a/cu/cu_event.py
+++ b/cu/cu_event.py
@@ -1,0 +1,79 @@
+from bs4 import BeautifulSoup
+import requests
+import re
+import json
+
+URL = "https://linktr.ee/cu_official"
+
+
+def find_html_arr(target, html_arr):
+    for one in html_arr:
+        if target in one.text:
+            return one
+    return None
+
+
+def get_html_from_URL(url):
+    response = requests.get(url)
+    if response.ok:
+        return BeautifulSoup(response.text, "html.parser")
+    else:
+        return None
+
+
+def get_starting_html(html):
+    h3_arr = html.find_all("h3")
+    event_h3 = find_html_arr("5월 이벤트", h3_arr)
+    event_h3_parent_div = event_h3.parent
+    return event_h3_parent_div
+
+
+def get_event_info_from(html):
+    if html.find("h3") != None:
+        return None
+
+    event_a_html = html.find("a")
+
+    event_info = {}
+    event_info["title"] = event_a_html.text
+    event_info["link"] = href = event_a_html.attrs["href"]
+
+    if "pocketcu.co.kr/event" in href:
+        content_html = get_html_from_URL(href)
+        if content_html != None:
+            event_info["date_period"] = re.sub(
+                r"\r|\n|\t", "", content_html.find("p", "date").text)
+
+    return event_info
+
+
+def get_event_list():
+    soup = get_html_from_URL(URL)
+    prev_div = get_starting_html(soup)
+
+    event_list = []
+
+    while (True):
+        current_div = prev_div.nextSibling
+        event_info = get_event_info_from(current_div)
+        if event_info == None:
+            break
+        event_list.append(event_info)
+        prev_div = current_div
+
+    return event_list
+
+
+def write_json(data, file_name):
+    json_data = json.dumps(data, ensure_ascii=False)
+    with open(file_name, 'w', encoding='utf-8') as file:
+        file.write(json_data)
+
+
+def run():
+    event_list = get_event_list()
+    write_json(event_list, "cu_event.json")
+
+
+if __name__ == "__main__":
+    run()

--- a/emart24/emart24_event.py
+++ b/emart24/emart24_event.py
@@ -1,0 +1,54 @@
+from bs4 import BeautifulSoup
+import requests
+import re
+import json
+
+domain_url = "https://www.emart24.co.kr"
+event_page_url = "https://www.emart24.co.kr/event/ing"
+
+
+def get_html_from_URL(url):
+    response = requests.get(url, verify=False)
+    if response.ok:
+        return BeautifulSoup(response.text, "html.parser")
+    else:
+        return None
+
+
+def get_event_info_from(html):
+    p_html = html.find("p")
+
+    [start, end, title] = [
+        one for one in re.split(r"\n *", p_html.text) if one]
+    link = domain_url + html.attrs["href"]
+    img_src = html.find("img").attrs["src"]
+
+    return {
+        "title": title,
+        "link": link,
+        "date_period": (start+end).replace(" ", "")
+    }
+
+
+def get_event_info_list_from(html):
+    event_html_list = html.find_all("a", "eventWrap")
+    result = []
+    for one in event_html_list:
+        result.append(get_event_info_from(one))
+    return result
+
+
+def write_json(data, file_name):
+    json_data = json.dumps(data, ensure_ascii=False)
+    with open(file_name, 'w', encoding='utf-8') as file:
+        file.write(json_data)
+
+
+def run():
+    html = get_html_from_URL(event_page_url)
+    event_list = get_event_info_list_from(html)
+    write_json(event_list, "emart24_event.json")
+
+
+if __name__ == "__main__":
+    run()

--- a/gs/gs_common.py
+++ b/gs/gs_common.py
@@ -1,0 +1,50 @@
+from dataclasses import dataclass
+import requests
+import json
+from bs4 import BeautifulSoup
+
+
+def find_in_arr(target: str, arr: list[str]):
+    for one in arr:
+        if one.find(target) > -1:
+            return one
+    return None
+
+
+def convert_info(json_data):
+    info_data = json.loads(json.loads(json_data))
+    return info_data
+
+
+def get_item_info(info):
+    return info["results"]
+
+
+def write_json(data, file_name):
+    json_data = json.dumps(data, ensure_ascii=False)
+    with open(file_name, 'w', encoding='utf-8') as file:
+        file.write(json_data)
+
+
+@dataclass
+class SessionToken:
+    session: str
+    token: str
+
+
+def get_session_token() -> SessionToken:
+    res = requests.get(
+        "http://gs25.gsretail.com/gscvs/ko/products/event-goods")
+    soup = BeautifulSoup(res.text, "html.parser")
+    cookie_list = res.headers["Set-Cookie"].split("; ")
+    session = find_in_arr("JSESSIONID", cookie_list).split("=")[1]
+    token = soup.find("input", attrs={"name": "CSRFToken"}).attrs['value']
+
+    return SessionToken(session, token)
+
+
+def init_setting_data(url: str):
+    session_token = get_session_token()
+
+    return {"url": f'{url}?CSRFToken={session_token.token}',
+            "cookies": {"JSESSIONID": session_token.session}}

--- a/gs/gs_event.py
+++ b/gs/gs_event.py
@@ -1,0 +1,98 @@
+from bs4 import BeautifulSoup
+import requests
+import re
+import json
+
+HEADERS = {
+    "Accept": "application/json, text/javascript, */*; q=0.01",
+    "Accept-Language": "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7",
+    "Connection": "keep-alive",
+    "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+    "Origin": "http://gs25.gsretail.com",
+    "Referer": "http://gs25.gsretail.com/gscvs/ko/products/event-goods"
+}
+
+domain_url = "http://gs25.gsretail.com"
+event_page_url = "http://gs25.gsretail.com/gscvs/ko/customer-engagement/event/current-events"
+
+
+def find_in_arr(target: str, arr: list[str]):
+    for one in arr:
+        if one.find(target) > -1:
+            return one
+    return None
+
+
+def get_session_token():
+    res = requests.get(
+        "http://gs25.gsretail.com/gscvs/ko/products/event-goods")
+    soup = BeautifulSoup(res.text, "html.parser")
+    cookie_list = res.headers["Set-Cookie"].split("; ")
+    session = find_in_arr("JSESSIONID", cookie_list).split("=")[1]
+    token = soup.find("input", attrs={"name": "CSRFToken"}).attrs['value']
+
+    return {"token": token, "session": session}
+
+
+def init_setting_data():
+    session_token = get_session_token()
+
+    return {"url": f'http://gs25.gsretail.com/board/boardList?CSRFToken={session_token["token"]}',
+            "cookies": {"JSESSIONID": session_token["session"]}}
+
+
+def get_raw_data_text(url, cookies, page_index, page_size):
+    dataParam = {
+        "pageNum": page_index, "pageSize": page_size, "modelName": "event", "parameterList": "brandCode:GS25@!@eventFlag:CURRENT"
+    }
+    res = requests.post(url=url, cookies=cookies,
+                        data=dataParam, headers=HEADERS)
+
+    if res.ok:
+        return res.text
+    else:
+        return None
+
+
+def convert_info(json_data):
+    info_data = json.loads(json.loads(json_data))
+    return info_data
+
+
+def get_item_info(info):
+    return info["results"]
+
+
+def get_item_info_list(url, cookies):
+    total_list = []
+    page_number = 1
+
+    while (True):
+        print(page_number)
+        raw_data = get_raw_data_text(url, cookies, page_number, 10)
+        info_data = convert_info(raw_data)
+        page_item_info = get_item_info(info_data)
+
+        if len(page_item_info) == 0:
+            break
+
+        total_list.extend(page_item_info)
+        page_number += 1
+
+    return total_list
+
+
+def write_json(data, file_name):
+    json_data = json.dumps(data, ensure_ascii=False)
+    with open(file_name, 'w', encoding='utf-8') as file:
+        file.write(json_data)
+
+
+def run():
+    setting_data = init_setting_data()
+    result = get_item_info_list(setting_data["url"], setting_data["cookies"])
+    write_json(result, "gs_event.json")
+
+
+if __name__ == "__main__":
+    run()

--- a/gs/gs_event.py
+++ b/gs/gs_event.py
@@ -1,7 +1,6 @@
-from bs4 import BeautifulSoup
 import requests
-import re
-import json
+
+from gs_common import convert_info, get_item_info,  init_setting_data, write_json
 
 HEADERS = {
     "Accept": "application/json, text/javascript, */*; q=0.01",
@@ -12,38 +11,13 @@ HEADERS = {
     "Referer": "http://gs25.gsretail.com/gscvs/ko/products/event-goods"
 }
 
-domain_url = "http://gs25.gsretail.com"
-event_page_url = "http://gs25.gsretail.com/gscvs/ko/customer-engagement/event/current-events"
-
-
-def find_in_arr(target: str, arr: list[str]):
-    for one in arr:
-        if one.find(target) > -1:
-            return one
-    return None
-
-
-def get_session_token():
-    res = requests.get(
-        "http://gs25.gsretail.com/gscvs/ko/products/event-goods")
-    soup = BeautifulSoup(res.text, "html.parser")
-    cookie_list = res.headers["Set-Cookie"].split("; ")
-    session = find_in_arr("JSESSIONID", cookie_list).split("=")[1]
-    token = soup.find("input", attrs={"name": "CSRFToken"}).attrs['value']
-
-    return {"token": token, "session": session}
-
-
-def init_setting_data():
-    session_token = get_session_token()
-
-    return {"url": f'http://gs25.gsretail.com/board/boardList?CSRFToken={session_token["token"]}',
-            "cookies": {"JSESSIONID": session_token["session"]}}
+DOMAIN_URL = "http://gs25.gsretail.com/board/boardList"
 
 
 def get_raw_data_text(url, cookies, page_index, page_size):
     dataParam = {
-        "pageNum": page_index, "pageSize": page_size, "modelName": "event", "parameterList": "brandCode:GS25@!@eventFlag:CURRENT"
+        "pageNum": page_index, "pageSize": page_size, "modelName": "event",
+        "parameterList": "brandCode:GS25@!@eventFlag:CURRENT"
     }
     res = requests.post(url=url, cookies=cookies,
                         data=dataParam, headers=HEADERS)
@@ -52,15 +26,6 @@ def get_raw_data_text(url, cookies, page_index, page_size):
         return res.text
     else:
         return None
-
-
-def convert_info(json_data):
-    info_data = json.loads(json.loads(json_data))
-    return info_data
-
-
-def get_item_info(info):
-    return info["results"]
 
 
 def get_item_info_list(url, cookies):
@@ -82,14 +47,8 @@ def get_item_info_list(url, cookies):
     return total_list
 
 
-def write_json(data, file_name):
-    json_data = json.dumps(data, ensure_ascii=False)
-    with open(file_name, 'w', encoding='utf-8') as file:
-        file.write(json_data)
-
-
 def run():
-    setting_data = init_setting_data()
+    setting_data = init_setting_data(DOMAIN_URL)
     result = get_item_info_list(setting_data["url"], setting_data["cookies"])
     write_json(result, "gs_event.json")
 


### PR DESCRIPTION
## Summary

편의점 이벤트 정보 추가(cu, gs, emart24)

## Description
- cu, gs, emart24 의 이벤트 정보 에서 타이틀, 상세 페이지 링크  정보를 json 파일로 생성함
- 7-eleven의 경우에는 해당 상세페이지 링크 없이 ajax:post 요청으로 렌더링된 html 데이터를 받아와서 그려줘서 보류함