### PR TITLE
Change path to explicit relative path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,23 +18,32 @@ python3 -m venv venv
 
 # 라이브러리 설치
 pip install -r requirements.txt
+```
 
-# 실행 cu, gs, seven11, emart24
-python3 ./cu/cu_item.py
-
-# 한번에 전부 실행
+- 한번에 아이템 실행
+```shell
 python3 multi_runner.py 
 ```
+
+
+- 개별 실행 cu, gs, seven11, emart24
+```shell
+python -m gs.gs_item 
+```
+
+
 
 ## Structure
 
 ```
 .
 ├── cu
+│   ├── cu_common.py
 │   ├── cu_event.py
 │   ├── cu_item.py
 │   └── cu_item_pb.py
 ├── emart24
+│   ├── emart24_common.py
 │   ├── emart24_event.py
 │   └── emart24_item.py
 ├── gs

--- a/cu/cu_event.py
+++ b/cu/cu_event.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 import requests
 from bs4 import BeautifulSoup
-from cu_common import write_json
+from .cu_common import write_json
 
 URL = "https://linktr.ee/cu_official"
 

--- a/cu/cu_event.py
+++ b/cu/cu_event.py
@@ -1,4 +1,3 @@
-import json
 import re
 from datetime import datetime
 

--- a/cu/cu_item.py
+++ b/cu/cu_item.py
@@ -1,4 +1,3 @@
-import json
 import re
 
 import requests

--- a/cu/cu_item.py
+++ b/cu/cu_item.py
@@ -3,7 +3,7 @@ import re
 
 import requests
 from bs4 import BeautifulSoup
-from cu_common import write_json
+from .cu_common import write_json
 
 URL = "https://cu.bgfretail.com/event/plusAjax.do"
 
@@ -26,6 +26,9 @@ def get_prod_list_html(data):
 
 def get_item_info(item):
     item_dict = {}
+
+    # 제품 아이디
+    item_dict["productId"] = item.find("a", "prod_item").attrs["href"]
 
     # 이미지 (img, src)
     item_dict["img"] = item.find("img").attrs["src"]

--- a/cu/cu_item_pb.py
+++ b/cu/cu_item_pb.py
@@ -1,4 +1,3 @@
-import json
 import re
 
 import requests

--- a/cu/cu_item_pb.py
+++ b/cu/cu_item_pb.py
@@ -4,7 +4,7 @@ import re
 import requests
 from bs4 import BeautifulSoup
 
-from cu_common import write_json
+from .cu_common import write_json
 
 URL = "https://cu.bgfretail.com/product/pbAjax.do"
 

--- a/emart24/emart24_common.py
+++ b/emart24/emart24_common.py
@@ -1,0 +1,7 @@
+import json
+
+
+def write_json(data, file_name):
+    json_data = json.dumps(data, ensure_ascii=False)
+    with open(file_name, 'w', encoding='utf-8') as file:
+        file.write(json_data)

--- a/emart24/emart24_event.py
+++ b/emart24/emart24_event.py
@@ -1,7 +1,9 @@
-from bs4 import BeautifulSoup
-import requests
 import re
-import json
+
+import requests
+from bs4 import BeautifulSoup
+
+from .emart24_common import write_json
 
 domain_url = "https://www.emart24.co.kr"
 event_page_url = "https://www.emart24.co.kr/event/ing"
@@ -36,12 +38,6 @@ def get_event_info_list_from(html):
     for one in event_html_list:
         result.append(get_event_info_from(one))
     return result
-
-
-def write_json(data, file_name):
-    json_data = json.dumps(data, ensure_ascii=False)
-    with open(file_name, 'w', encoding='utf-8') as file:
-        file.write(json_data)
 
 
 def run():

--- a/emart24/emart24_item.py
+++ b/emart24/emart24_item.py
@@ -1,7 +1,9 @@
-from bs4 import BeautifulSoup
-import requests
-import json
 import time
+
+import requests
+from bs4 import BeautifulSoup
+
+from .emart24_common import write_json
 
 
 def get_raw_data_html(page_index):
@@ -75,9 +77,7 @@ def run():
         page_index += 1
         time.sleep(0.1)
 
-    json_data = json.dumps(total_list, ensure_ascii=False)
-    with open("emart24_item.json", 'w', encoding='utf-8') as file:
-        file.write(json_data)
+    write_json(total_list, "emart24_item.json")
 
 
 if __name__ == "__main__":

--- a/gs/gs_event.py
+++ b/gs/gs_event.py
@@ -1,5 +1,5 @@
-from gs_common import (HEADERS, convert_info, get_item_info, get_raw_data_text,
-                       init_setting_data, write_json)
+from .gs_common import (HEADERS, convert_info, get_item_info, get_raw_data_text,
+                        init_setting_data, write_json)
 
 DOMAIN_URL = "http://gs25.gsretail.com/board/boardList"
 

--- a/gs/gs_item.py
+++ b/gs/gs_item.py
@@ -1,5 +1,5 @@
-from gs_common import (HEADERS, convert_info, get_item_info, get_raw_data_text,
-                       init_setting_data, write_json)
+from .gs_common import (HEADERS, convert_info, get_item_info, get_raw_data_text,
+                        init_setting_data, write_json)
 
 PAGE_SIZE = 16
 

--- a/gs/gs_item_pb.py
+++ b/gs/gs_item_pb.py
@@ -1,5 +1,5 @@
-from gs_common import (HEADERS, convert_info, get_raw_data_text,
-                       init_setting_data, write_json)
+from .gs_common import (HEADERS, convert_info, get_raw_data_text,
+                        init_setting_data, write_json)
 
 PAGE_SIZE = 16
 

--- a/seven11/seven11_item.py
+++ b/seven11/seven11_item.py
@@ -1,4 +1,4 @@
-from seven11_common import ItemType, get_data_by_type, json_write_file
+from .seven11_common import ItemType, get_data_by_type, json_write_file
 
 
 def run():

--- a/seven11/seven11_new_product.py
+++ b/seven11/seven11_new_product.py
@@ -1,4 +1,4 @@
-from seven11_common import ItemType, get_data_by_type, json_write_file
+from .seven11_common import ItemType, get_data_by_type, json_write_file
 
 
 def run():


### PR DESCRIPTION
## Summary
기본에 import path를 명시적 상대 경로로 수정

## Detail

- 공통된 코드들을 각각 common 파일로 분리해서 사용하는데 root 경로 multi_runner.py 에서 발생한 에러 해결
```
Traceback (most recent call last):
  File "/.../multi_runner.py", line 7, in <module>
    from cu.cu_item import run as cu_crawler
  File "/.../cu/cu_item.py", line 6, in <module>
    from cu_common import write_json
ModuleNotFoundError: No module named 'cu_common'
```

- 기존 방법대로 패키지 안 파일 실행시 `ImportError: attempted relative import with no known parent package` 발생
  - 파이썬3.3 이상에서는 `__init__.py` 가 없어도 패키지로 인식
  - 파이썬 인터프리터가 상대적 import 모듈 위치를 정할때 `__name__` 속성으로 결정되는 데 이 위치를 알지 못해 에러 발.
  - 이를 해결하기 위해 패키지 내 스크립트 실행 방법 수정 `루트 경로에서 python -m cu.cu_item`  
