### PR TITLE
Add cu all product crawling

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ pip install -r requirements.txt
 
 - 한번에 아이템 실행
 ```shell
+# 각 패키지 별로 코드들이 있으니 각 원하는 상품에 따라서 multi_runner에 세팅 필요
 python3 multi_runner.py 
 ```
 
@@ -41,6 +42,7 @@ python -m gs.gs_item
 │   ├── cu_common.py
 │   ├── cu_event.py
 │   ├── cu_item.py
+│   ├── cu_item_all.py
 │   └── cu_item_pb.py
 ├── emart24
 │   ├── emart24_common.py
@@ -64,11 +66,18 @@ python -m gs.gs_item
 ## Dependencies
 
 ```
+aiohttp==3.8.4
+aiosignal==1.3.1
+async-timeout==4.0.2
+attrs==23.1.0
 beautifulsoup4==4.12.2
 certifi==2023.5.7
 charset-normalizer==3.1.0
+frozenlist==1.3.3
 idna==3.4
+multidict==6.0.4
 requests==2.31.0
 soupsieve==2.4.1
 urllib3==2.0.2
+yarl==1.9.2
 ```

--- a/cu/cu_item_all.py
+++ b/cu/cu_item_all.py
@@ -1,0 +1,130 @@
+import re
+
+import requests
+from bs4 import BeautifulSoup
+
+from .cu_common import write_json
+
+URL = "https://cu.bgfretail.com/product/productAjax.do"
+
+
+"""
+searchMainCategory
+10 : 간편식사
+20 : 즉석조리
+30 : 과자류
+40 : 아이스크림
+50 : 식품
+60 : 음료
+70 : 생활용품
+"""
+MAIN_CATEGORIES_NUM = [10, 20, 30, 40, 50, 60, 70]
+
+
+def get_main_category_name(category: str):
+    match(category):
+        case 10: return "간편식사"
+        case 20: return "즉석조리"
+        case 30: return "과자류"
+        case 40: return "아이스크림"
+        case 50: return "식품"
+        case 60: return "음료"
+        case 70: return "생활용품"
+
+
+def get_raw_data_text(url, page_index, search_main_category, list_type=0):
+    req = requests.post(
+        url=url,
+        data={
+            "pageIndex": page_index,
+            "searchMainCategory": search_main_category,
+            "searchSubCategory": "",
+            "listType": list_type,
+            "searchCondition": "setA",
+            "searchUseYn": "N",
+            "gdIdx": 0,
+            "codeParent": search_main_category,
+            "user_id": "",
+            "search1": "",
+            "search2": "",
+            "searchKeyword": "",
+        }
+    )
+
+    if req.ok:
+        return req.text
+    else:
+        return None
+
+
+def get_prod_list_html(data):
+    soup = BeautifulSoup(data, "html.parser")
+    prod_list = soup.find_all("li", "prod_list")
+    return prod_list
+
+
+def get_item_info(item):
+    item_dict = {}
+
+    # 제품 아이디
+    item_dict["productId"] = re.findall(
+        r"\d+", item.find("div", "prod_img").attrs['onclick'])[0]
+
+    # 이미지 (img, src)
+    item_dict["img"] = item.find("img").attrs["src"]
+
+    # 제품명
+    item_dict["name"] = item.find("div", "name").text
+
+    # 제품 가격
+    item_dict["price"] = item.find("div", "price").text.replace("원", "")
+
+    # 행사 종류 (1+1, 2+1)
+    item_dict["type"] = re.sub(r"\n| \n", "", item.find("div", "badge").text)
+
+    # 태그 (없음, new, best)
+    if item.find("div", "tag").find("img") != None:
+        item_dict["tag"] = (item.find("div", "tag").find("img")).attrs["alt"]
+    else:
+        item_dict["tag"] = ""
+
+    return item_dict
+
+
+def get_item_list_info(prod_list):
+    result_list = []
+    for prod in prod_list:
+        result_list.append(get_item_info(prod))
+    return result_list
+
+
+def get_item_info_list(main_category):
+    page_index = 1
+    total_list = []
+
+    while True:
+        print(get_main_category_name(main_category), page_index)
+        raw_data = get_raw_data_text(URL, page_index, main_category)
+        prod_list = get_prod_list_html(raw_data)
+
+        if len(prod_list) == 0:
+            break
+
+        item_info_list = get_item_list_info(prod_list)
+        total_list.extend(item_info_list)
+        page_index += 1
+
+    return total_list
+
+
+def run():
+    result = []
+    # 7 catogories and almost 165 pages
+    for main_category in MAIN_CATEGORIES_NUM:
+        result.append(get_item_info_list(main_category))
+
+    write_json(result, "cu_item_all.json")
+
+
+if __name__ == "__main__":
+    run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,14 @@
+aiohttp==3.8.4
+aiosignal==1.3.1
+async-timeout==4.0.2
+attrs==23.1.0
 beautifulsoup4==4.12.2
 certifi==2023.5.7
 charset-normalizer==3.1.0
+frozenlist==1.3.3
 idna==3.4
+multidict==6.0.4
 requests==2.31.0
 soupsieve==2.4.1
 urllib3==2.0.2
+yarl==1.9.2


### PR DESCRIPTION
## Summary
CU 전체 상품 페이지의 상품 정보 추가 

## Description
- `https://cu.bgfretail.com/product/productAjax.do` 로 요청, 몇가지 formData 변경
- 각 카테고리 별 페이지가 있고 총 161페이지가 있음. 후반부로 갈수록 응답이 느려지는 현상 존재
- 총 7개의 서브 카테고리가 있어서 `asyncio`, `aiohttp` 를 활용해서 비동기로 진행
- 해당 코드에서는 상세상품 페이지까지 접근하지 않음 (개별 상품 대략 6400개) 
- 각 카테고리 별 정보 또한 json에 반영하지 않음