### PR TITLE
Add crawling code about fresh food pages

### DIFF
--- a/emart24/emart24_common.py
+++ b/emart24/emart24_common.py
@@ -1,7 +1,101 @@
 import json
+import time
+from typing import Any, Callable
+
+import requests
+from bs4 import BeautifulSoup
 
 
 def write_json(data, file_name):
     json_data = json.dumps(data, ensure_ascii=False)
     with open(file_name, 'w', encoding='utf-8') as file:
         file.write(json_data)
+
+
+def get_raw_data_html(url):
+    res = requests.get(url, verify=False)
+    if res.ok:
+        return res.text
+    else:
+        return None
+
+
+def get_item_list_html(data):
+    soup = BeautifulSoup(data, "html.parser")
+    item_list = soup.find_all("div", "itemWrap")
+    return item_list
+
+
+def get_item_info(item):
+    item_type = ""
+    item_type_text = ""
+
+    if item.find("span", "floatR") != None:
+        item_type = item.find("span", "floatR").attrs["class"][0]
+
+    if item_type != "":
+        item_type_text = item.find("span", item_type).text
+
+    item_title = item.find("div", "itemtitle").text.replace("\n", "")
+    item_img = item.find("div", "itemImg").find("img").attrs["src"]
+    item_price = item.find("a", "price").text
+    item_price_off = 0
+    item_dum_img = ""
+
+    match(item_type):
+        case "sale":
+            item_price_off = getattr(item.find("a", "priceOff"), "text", "")
+        case "dum":
+            item_dum_img = item.find("div", "dumgift").find("img").attrs["src"]
+        case "onepl":
+            pass
+        case "twopl":
+            pass
+        case "tripl":
+            pass
+        case _:
+            pass
+
+    return {
+        "type": item_type,
+        "type_text": item_type_text,
+        "item_img": item_img,
+        "title": item_title,
+        "price": item_price,
+        "price_off": item_price_off,
+        "dum_img": item_dum_img
+    }
+
+
+def get_item_list_info(item_list):
+    result_list = []
+    for item in item_list:
+        result_list.append(get_item_info(item))
+    return result_list
+
+
+def get_item_info_from_url(url):
+    raw_data = get_raw_data_html(url)
+    item_list_html = get_item_list_html(raw_data)
+    item_info_list = []
+
+    if len(item_list_html) > 0:
+        item_info_list = get_item_list_info(item_list_html)
+
+    return item_info_list
+
+
+def crawling_runner_by(create_request_url: Callable[[Any], str]):
+    page_index = 1
+    total_list = []
+    prev_len = -1
+
+    while prev_len < len(total_list):
+        print(page_index)
+        prev_len = len(total_list)
+        url = create_request_url(page_index)
+        total_list.extend(get_item_info_from_url(url))
+        page_index += 1
+        time.sleep(0.1)
+
+    return total_list

--- a/emart24/emart24_differentiated_product.py
+++ b/emart24/emart24_differentiated_product.py
@@ -1,0 +1,39 @@
+import time
+
+import requests
+
+from emart24.emart24_item import get_item_list_html, get_item_list_info
+from .emart24_common import write_json
+
+
+def get_raw_data_html(page_index):
+    req = requests.get(
+        f"https://www.emart24.co.kr/goods/pl?search=&page={page_index}&category_seq=&align=", verify=False)
+    if req.ok:
+        return req.text
+    else:
+        return None
+
+
+def run():
+    page_index = 1
+    total_list = []
+
+    while True:
+        print(page_index)
+        raw_data = get_raw_data_html(page_index)
+        item_list_html = get_item_list_html(raw_data)
+
+        if len(item_list_html) == 0:
+            break
+
+        item_info_list = get_item_list_info(item_list_html)
+        total_list.extend(item_info_list)
+        page_index += 1
+        time.sleep(0.1)
+
+    write_json(total_list, "emart24_differentiated_product.json")
+
+
+if __name__ == "__main__":
+    run()

--- a/emart24/emart24_differentiated_product.py
+++ b/emart24/emart24_differentiated_product.py
@@ -1,37 +1,12 @@
-import time
-
-import requests
-
-from emart24.emart24_item import get_item_list_html, get_item_list_info
-from .emart24_common import write_json
+from .emart24_common import crawling_runner_by, write_json
 
 
-def get_raw_data_html(page_index):
-    req = requests.get(
-        f"https://www.emart24.co.kr/goods/pl?search=&page={page_index}&category_seq=&align=", verify=False)
-    if req.ok:
-        return req.text
-    else:
-        return None
+def create_request_url(page_index):
+    return f"https://www.emart24.co.kr/goods/pl?search=&page={page_index}&category_seq=&align="
 
 
 def run():
-    page_index = 1
-    total_list = []
-
-    while True:
-        print(page_index)
-        raw_data = get_raw_data_html(page_index)
-        item_list_html = get_item_list_html(raw_data)
-
-        if len(item_list_html) == 0:
-            break
-
-        item_info_list = get_item_list_info(item_list_html)
-        total_list.extend(item_info_list)
-        page_index += 1
-        time.sleep(0.1)
-
+    total_list = crawling_runner_by(create_request_url)
     write_json(total_list, "emart24_differentiated_product.json")
 
 

--- a/emart24/emart24_fresh_food.py
+++ b/emart24/emart24_fresh_food.py
@@ -1,0 +1,39 @@
+import time
+
+import requests
+
+from emart24.emart24_item import get_item_list_html, get_item_list_info
+from .emart24_common import write_json
+
+
+def get_raw_data_html(page_index):
+    req = requests.get(
+        f"https://www.emart24.co.kr/goods/ff?search=&page={page_index}&category_seq=&align=", verify=False)
+    if req.ok:
+        return req.text
+    else:
+        return None
+
+
+def run():
+    page_index = 1
+    total_list = []
+
+    while True:
+        print(page_index)
+        raw_data = get_raw_data_html(page_index)
+        item_list_html = get_item_list_html(raw_data)
+
+        if len(item_list_html) == 0:
+            break
+
+        item_info_list = get_item_list_info(item_list_html)
+        total_list.extend(item_info_list)
+        page_index += 1
+        time.sleep(0.1)
+
+    write_json(total_list, "emart24_fresh_food.json")
+
+
+if __name__ == "__main__":
+    run()

--- a/emart24/emart24_fresh_food.py
+++ b/emart24/emart24_fresh_food.py
@@ -1,37 +1,12 @@
-import time
-
-import requests
-
-from emart24.emart24_item import get_item_list_html, get_item_list_info
-from .emart24_common import write_json
+from .emart24_common import crawling_runner_by, write_json
 
 
-def get_raw_data_html(page_index):
-    req = requests.get(
-        f"https://www.emart24.co.kr/goods/ff?search=&page={page_index}&category_seq=&align=", verify=False)
-    if req.ok:
-        return req.text
-    else:
-        return None
+def create_request_url(page_index):
+    return f"https://www.emart24.co.kr/goods/ff?search=&page={page_index}&category_seq=&align="
 
 
 def run():
-    page_index = 1
-    total_list = []
-
-    while True:
-        print(page_index)
-        raw_data = get_raw_data_html(page_index)
-        item_list_html = get_item_list_html(raw_data)
-
-        if len(item_list_html) == 0:
-            break
-
-        item_info_list = get_item_list_info(item_list_html)
-        total_list.extend(item_info_list)
-        page_index += 1
-        time.sleep(0.1)
-
+    total_list = crawling_runner_by(create_request_url)
     write_json(total_list, "emart24_fresh_food.json")
 
 

--- a/emart24/emart24_item.py
+++ b/emart24/emart24_item.py
@@ -22,8 +22,15 @@ def get_item_list_html(data):
 
 
 def get_item_info(item):
-    item_type = item.find("span", "floatR").attrs["class"][0]
-    item_type_text = item.find("span", item_type).text
+    item_type = ""
+    item_type_text = ""
+
+    if item.find("span", "floatR") != None:
+        item_type = item.find("span", "floatR").attrs["class"][0]
+
+    if item_type != "":
+        item_type_text = item.find("span", item_type).text
+
     item_title = item.find("div", "itemtitle").text.replace("\n", "")
     item_img = item.find("div", "itemImg").find("img").attrs["src"]
     item_price = item.find("a", "price").text
@@ -40,6 +47,8 @@ def get_item_info(item):
         case "twopl":
             pass
         case "tripl":
+            pass
+        case _:
             pass
 
     return {

--- a/emart24/emart24_item.py
+++ b/emart24/emart24_item.py
@@ -1,91 +1,12 @@
-import time
-
-import requests
-from bs4 import BeautifulSoup
-
-from .emart24_common import write_json
+from .emart24_common import (crawling_runner_by, write_json)
 
 
-def get_raw_data_html(page_index):
-    req = requests.get(
-        f"https://www.emart24.co.kr/goods/event?search=&page={page_index}&category_seq=&align=", verify=False)
-    if req.ok:
-        return req.text
-    else:
-        return None
-
-
-def get_item_list_html(data):
-    soup = BeautifulSoup(data, "html.parser")
-    item_list = soup.find_all("div", "itemWrap")
-    return item_list
-
-
-def get_item_info(item):
-    item_type = ""
-    item_type_text = ""
-
-    if item.find("span", "floatR") != None:
-        item_type = item.find("span", "floatR").attrs["class"][0]
-
-    if item_type != "":
-        item_type_text = item.find("span", item_type).text
-
-    item_title = item.find("div", "itemtitle").text.replace("\n", "")
-    item_img = item.find("div", "itemImg").find("img").attrs["src"]
-    item_price = item.find("a", "price").text
-    item_price_off = 0
-    item_dum_img = ""
-
-    match(item_type):
-        case "sale":
-            item_price_off = getattr(item.find("a", "priceOff"), "text", "")
-        case "dum":
-            item_dum_img = item.find("div", "dumgift").find("img").attrs["src"]
-        case "onepl":
-            pass
-        case "twopl":
-            pass
-        case "tripl":
-            pass
-        case _:
-            pass
-
-    return {
-        "type": item_type,
-        "type_text": item_type_text,
-        "item_img": item_img,
-        "title": item_title,
-        "price": item_price,
-        "price_off": item_price_off,
-        "dum_img": item_dum_img
-    }
-
-
-def get_item_list_info(item_list):
-    result_list = []
-    for item in item_list:
-        result_list.append(get_item_info(item))
-    return result_list
+def create_request_url(page_index):
+    return f"https://www.emart24.co.kr/goods/event?search=&page={page_index}&category_seq=&align="
 
 
 def run():
-    page_index = 1
-    total_list = []
-
-    while True:
-        print(page_index)
-        raw_data = get_raw_data_html(page_index)
-        item_list_html = get_item_list_html(raw_data)
-
-        if len(item_list_html) == 0:
-            break
-
-        item_info_list = get_item_list_info(item_list_html)
-        total_list.extend(item_info_list)
-        page_index += 1
-        time.sleep(0.1)
-
+    total_list = crawling_runner_by(create_request_url)
     write_json(total_list, "emart24_item.json")
 
 

--- a/gs/gs_item_fresh.py
+++ b/gs/gs_item_fresh.py
@@ -1,0 +1,49 @@
+from .gs_common import (HEADERS, convert_info, get_raw_data_text,
+                        init_setting_data, write_json)
+
+PAGE_SIZE = 16
+
+TARGET_URL = "http://gs25.gsretail.com/products/youus-freshfoodDetail-search"
+
+
+def create_pb_data_param(page_index, page_size):
+    return {
+        "pageNum": page_index, "pageSize": page_size,
+        "searchSrvFoodCK": "FreshFoodKey",
+        "searchSort": "searchALLSort",
+        "searchProduct": "productALL"
+    }
+
+
+def get_item_info(info):
+    return info["SubPageListData"]
+
+
+def get_item_info_list(url, cookies):
+    total_list = []
+    page_number = 1
+
+    while (True):
+        print(page_number)
+        data_param = create_pb_data_param(page_number, PAGE_SIZE)
+        raw_data = get_raw_data_text(url, HEADERS, cookies, data_param)
+        info_data = convert_info(raw_data)
+        page_item_info = get_item_info(info_data)
+
+        if len(page_item_info) == 0:
+            break
+
+        total_list.extend(page_item_info)
+        page_number += 1
+
+    return total_list
+
+
+def run():
+    setting_data = init_setting_data(TARGET_URL)
+    result = get_item_info_list(setting_data["url"], setting_data["cookies"])
+    write_json(result, "gs_item_fresh.json")
+
+
+if __name__ == "__main__":
+    run()

--- a/seven11/seven11_common.py
+++ b/seven11/seven11_common.py
@@ -1,6 +1,6 @@
 import json
 from enum import Enum
-from typing import Callable
+from typing import Callable, Union
 
 import requests
 from bs4 import BeautifulSoup
@@ -17,7 +17,14 @@ class ItemType(Enum):
     NEW_PRODUCT = 8
 
 
-def get_item_type_text(item_type: ItemType):
+class FreshFoodType(Enum):
+    TOTAL = ""
+    LUNCH_BOX = "mini"
+    GIMBAP = "noodle"
+    SANDWICH_HAMBURGER = "d_group"
+
+
+def get_item_type_text(item_type: Union[ItemType, FreshFoodType]):
     match(item_type):
         case ItemType.ONE_ONE: return "1+1"
         case ItemType.TWO_ONE: return "2+1"
@@ -25,6 +32,7 @@ def get_item_type_text(item_type: ItemType):
         case ItemType.DISCOUNT: return "discount"
         case ItemType.PB: return "pb"
         case ItemType.NEW_PRODUCT: return "new"
+        case FreshFoodType.TOTAL: return "freshFood"
 
 
 # page1는 13개, 그 이후 페이지는 10개씩
@@ -110,7 +118,8 @@ INFO_FUNCTIONS = {
     ItemType.GIFT:  get_info_gift,
     ItemType.DISCOUNT:  get_basic_info_product,
     ItemType.PB: get_basic_info_product,
-    ItemType.NEW_PRODUCT: get_basic_info_product
+    ItemType.NEW_PRODUCT: get_basic_info_product,
+    FreshFoodType.TOTAL: get_basic_info_product,
 }
 
 

--- a/seven11/seven11_fresh_food.py
+++ b/seven11/seven11_fresh_food.py
@@ -1,0 +1,65 @@
+import requests
+from bs4 import BeautifulSoup
+
+from .seven11_common import (INFO_FUNCTIONS, FreshFoodType,
+                             get_data_by_fresh_food_type, get_item_type_text,
+                             iterate_item_info_function, json_write_file)
+
+
+# fresh food 도시락/조리면 삼각김밥/김밥 샌드위치/햄버거
+def get_fresh_food_html_text_data(itemType: FreshFoodType, page_size: int):
+    res = requests.post(url="https://www.7-eleven.co.kr/product/dosirakNewMoreAjax.asp", data={
+        "intPageSize": page_size, "pTab": itemType.value})
+    if res.ok:
+        return res.text
+    else:
+        return None
+
+
+def parse_fresh_food_item_list(text: str):
+    soup = BeautifulSoup(text, "html.parser")
+    parent_ul = soup.select("div.dosirak_list > ul")
+
+    if len(parent_ul) == 0:
+        return []
+
+    item_list = parent_ul[0].findChildren("li",  recursive=False)[1:-1]
+    return item_list
+
+
+def get_data_by_fresh_food_type(itemType: FreshFoodType):
+    print(get_item_type_text(itemType))
+
+    info_function = INFO_FUNCTIONS[itemType]
+
+    page_size = 0
+
+    result_list = []
+
+    while (True):
+        page_size += 150
+        page_data = get_fresh_food_html_text_data(itemType, page_size)
+        page_item_list = parse_fresh_food_item_list(page_data)
+        page_item_list_size = len(page_item_list)
+
+        if page_item_list_size == 0:
+            break
+
+        result_list.extend(iterate_item_info_function(
+            page_item_list, itemType, info_function))
+
+        if page_item_list_size < page_size:
+            break
+
+    return result_list
+
+
+def run():
+    total_list = []
+    total_list.extend(get_data_by_fresh_food_type(FreshFoodType.TOTAL))
+
+    json_write_file("seven11_fresh_food.json", total_list)
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary
GS25, 세븐일레븐, 이마트24 의 Fresh Food 등의 페이지 정보 관련 코드 추가 

## Description 

### GS25
- url, params 가 조금 다르다
- pb, freshfood가 서로 비슷하고, item과는 살짝 응답 구조가 다르다 

### 세븐일레븐
- 세븐일레븐 Fresh Food 페이지는 이달의 증정할인 (1+1, 2+1, 할인 등) 페이지와 구조가 살짝 다름
- 초기 로딩 10개, 이후 4개 씩 되는데 누적한 전체 페이지로 불러오기 때문에 한번에 150개 요청해서 요청을 줄임

### 이마트 24

- 이마트 24는 할인 아이템, Fresh Food, 차별화 상품이 URL만 다르고 구조가 같다
- 중복 코드들을 common 파일로 정리했다. 
- Fresh Food, 차별화 상품이 타입, dum_img이 따로 없어서 공백으로 처리했다.
- 할인도 없기 때문에 초기값인 0이다. 